### PR TITLE
Allow configuring Cloudflare worker base

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10  # жорстка межа на весь крок build
+    env:
+      CF_WORKER_BASE: ${{ secrets.CF_WORKER_BASE || vars.CF_WORKER_BASE || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # btc-futures-analysis
+
+## Configuration
+
+`analyze.py` can optionally route Binance API traffic through a Cloudflare Worker.
+Provide the worker base URL via the `CF_WORKER_BASE` environment variable to
+prepend it to the list of REST hosts without editing the source code.
+
+```bash
+export CF_WORKER_BASE="https://<your-subdomain>.workers.dev"
+python -u analyze.py
+```
+
+If the variable is unset or empty the script will continue to use the default
+Binance endpoints.

--- a/analyze.py
+++ b/analyze.py
@@ -3,14 +3,16 @@ import os, time, json, requests
 import pandas as pd
 from datetime import datetime, timezone
 
+CF_WORKER_BASE = (os.getenv("CF_WORKER_BASE") or "").strip()
+# Optional Cloudflare Worker base URL injected ahead of Binance hosts via CF_WORKER_BASE.
+
 FAPI_BASES = [
+    *([CF_WORKER_BASE] if CF_WORKER_BASE else []),
     "https://fapi.binance.com",
     "https://fapi1.binance.com",
     "https://fapi2.binance.com",
     "https://fapi3.binance.com",
     "https://fapi4.binance.com",
-    # опційно: свій CF-Worker першим у списку
-    # "https://<your-subdomain>.workers.dev",
 ]
 
 USE_CONTINUOUS = False  # True -> /continuousKlines за PAIR/CONTRACT_TYPE


### PR DESCRIPTION
## Summary
- allow `analyze.py` to prepend a Cloudflare Worker base URL via the `CF_WORKER_BASE` environment variable
- document how to supply the worker URL without touching the code
- surface the worker base environment variable in the scheduled workflow for secrets or local overrides

## Testing
- python -m compileall analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68e1252302a88323aaba9f821442b51d